### PR TITLE
Add new sites, fix preview for nested routes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,6 @@ export default defineConfig({
   },
   adapter: netlify(),
   prefetch: true,
-  trailingSlash: "never",
   redirects: {
     "/ch/00": "/",
     "/about": "/credits",

--- a/src/channels/01-games.yml
+++ b/src/channels/01-games.yml
@@ -54,6 +54,12 @@ schedule:
     - "23:30":
   tuesday:
     - "00:00":
+        title: Peter Talisman
+        author:
+          - Callum Copley
+          - Ben West
+          - Joseph Pleass
+        url: https://petertalisman.quest/
     - "00:30":
     - "01:00":
     - "01:30":

--- a/src/channels/02-art.yml
+++ b/src/channels/02-art.yml
@@ -77,6 +77,11 @@ schedule:
     - "09:00":
     - "09:30":
     - "10:00":
+        title: A Friend is Writing
+        author:
+          - Ben West
+          - Callum Copley
+        url: https://a-friend-is-writing.bewe.me/
     - "10:30":
     - "11:00":
     - "11:30":
@@ -89,6 +94,8 @@ schedule:
     - "15:00":
     - "15:30":
     - "16:00":
+        title: nature
+        url: https://xixxii.neocities.org/projects/weirdweboctober24/01-nature
     - "16:30":
     - "17:00":
     - "17:30":

--- a/src/channels/04-personal.yml
+++ b/src/channels/04-personal.yml
@@ -24,6 +24,9 @@ schedule:
     - "08:00":
     - "08:30":
     - "09:00":
+        title: Lean Rada
+        author: Lean Rada
+        url: https://leanrada.com/
     - "09:30":
     - "10:00":
     - "10:30":

--- a/src/channels/05-poetry.yml
+++ b/src/channels/05-poetry.yml
@@ -258,6 +258,8 @@ schedule:
     - "09:00":
     - "09:30":
     - "10:00":
+        title: FORM
+        url: https://www.c3.hu/collection/form/index1.html
     - "10:30":
     - "11:00":
     - "11:30":

--- a/src/channels/06-single-use.yml
+++ b/src/channels/06-single-use.yml
@@ -223,6 +223,9 @@ schedule:
     - "23:30":
   friday:
     - "00:00":
+        title: Nothing
+        author: Maze Heart
+        url: https://nothing.mvze.net/
     - "00:30":
     - "01:00":
     - "01:30":
@@ -359,6 +362,9 @@ schedule:
     - "13:00":
     - "13:30":
     - "14:00":
+        title: Seventh Sanctum
+        author: Steven Savage
+        url: https://www.seventhsanctum.com/
     - "14:30":
     - "15:00":
     - "15:30":

--- a/src/channels/08-archives.yml
+++ b/src/channels/08-archives.yml
@@ -101,6 +101,9 @@ schedule:
     - "23:30":
   wednesday:
     - "00:00":
+        title: Stolen Buttons
+        author: Anatoly Zenkov
+        url: https://anatolyzenkov.com/stolen-buttons
     - "00:30":
     - "01:00":
     - "01:30":
@@ -150,6 +153,9 @@ schedule:
     - "23:30":
   thursday:
     - "00:00":
+        title: Genderswap FM
+        author: Eva Decker
+        url: https://genderswap.fm/
     - "00:30":
     - "01:00":
     - "01:30":
@@ -331,6 +337,9 @@ schedule:
     - "12:00":
     - "12:30":
     - "13:00":
+        title: Genders.WTF
+        author: Effy Elden
+        url: https://genders.wtf/
     - "13:30":
     - "14:00":
     - "14:30":

--- a/src/channels/09-misc.yml
+++ b/src/channels/09-misc.yml
@@ -329,6 +329,9 @@ schedule:
     - "10:00":
     - "10:30":
     - "11:00":
+        title: Very Interactive
+        author: Laurel Schwulst
+        url: https://veryinteractive.net/
     - "11:30":
     - "12:00":
     - "12:30":

--- a/src/pages/test/[...url].astro
+++ b/src/pages/test/[...url].astro
@@ -3,8 +3,8 @@ import IFrame from "@components/IFrame.astro";
 import Television from "@components/Television.astro";
 import Layout from "@layouts/Layout.astro";
 
-const { id } = Astro.params;
-if (!id) return Astro.redirect("/test");
+const { url } = Astro.params;
+if (!url) return Astro.redirect("/test");
 ---
 
 <Layout title="Site Preview">
@@ -17,6 +17,6 @@ if (!id) return Astro.redirect("/test");
     channelId="PRE"
     channelName="Preview"
   >
-    <IFrame src={`https://${id}`} />
+    <IFrame src={`https://${url}`} />
   </Television>
 </Layout>


### PR DESCRIPTION
- Remove `trailingSlash: never` from Astro config, which was causing site previews to fail
- Change `[id].astro` to `[...url].astro` to spread route in case of previewing a site which exists deeper than the root domain
- Add a handful of new sites ❤️