### PR TITLE
Fix menu settings not re-initializing after page load, improve viewer count streaming

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,15 +1,3 @@
 [dev]
   framework = "astro"
   targetPort = 4321
-
-[build]
-  command = "npm run build"
-  publish = "dist"
-
-[[edge_functions]]
-  function = "live-stats"
-  path = "/.netlify/edge-functions/live-stats"
-
-[build.environment]
-  FATHOM_API_KEY = "your-api-key"
-  FATHOM_SITE_ID = "your-site-id"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,15 @@
 [dev]
   framework = "astro"
   targetPort = 4321
+
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[[edge_functions]]
+  function = "live-stats"
+  path = "/.netlify/edge-functions/live-stats"
+
+[build.environment]
+  FATHOM_API_KEY = "your-api-key"
+  FATHOM_SITE_ID = "your-site-id"

--- a/netlify/edge-functions/visitors.ts
+++ b/netlify/edge-functions/visitors.ts
@@ -2,10 +2,8 @@ import { getStore } from "@netlify/blobs";
 import type { Config, Context } from "@netlify/edge-functions";
 
 const VISITORS_KEY = "visitor_counts";
-// Fathom max limit: 6 (10 times per minute)
-// Increase to 15 seconds to avoid accidental triggering of rate limit
 const CACHE_TTL = 15;
-const MAX_HISTORY_POINTS = 10;
+const MAX_HISTORY_POINTS = 8;
 const SITE_ID = "EPXKTQED";
 
 interface VisitorData {
@@ -196,7 +194,86 @@ function createVisitorResponse(
   };
 }
 
-export default async (_request: Request, _context: Context) => {
+/**
+ * Handles Server-Sent Events (SSE) for real-time visitor updates
+ */
+async function handleSSE(request: Request): Promise<Response> {
+  const headers = new Headers({
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+
+  const stream = new TransformStream();
+  const writer = stream.writable.getWriter();
+  const store = getStore("visitors-cache");
+
+  const sendStats = async () => {
+    try {
+      const visitorData = await getVisitorData(store);
+      const recentResponse = getRecentData(visitorData);
+
+      if (recentResponse) {
+        writer.write(
+          new TextEncoder().encode(
+            `data: ${JSON.stringify(recentResponse)}\n\n`,
+          ),
+        );
+        return;
+      }
+
+      // If no recent data, fetch from Fathom API
+      try {
+        const total = await fetchFathomData();
+        const updatedData = await updateVisitorData(store, visitorData, total);
+        const response = createVisitorResponse(updatedData, total);
+
+        writer.write(
+          new TextEncoder().encode(`data: ${JSON.stringify(response)}\n\n`),
+        );
+      } catch (error) {
+        // If Fathom errors, just send existing data
+        const response = {
+          total: visitorData[visitorData.length - 1]?.count ?? 0,
+          history: visitorData.map((data) => data.count),
+        };
+
+        writer.write(
+          new TextEncoder().encode(`data: ${JSON.stringify(response)}\n\n`),
+        );
+      }
+    } catch (error) {
+      console.error("Error in SSE handler:", error);
+      writer.write(
+        new TextEncoder().encode(
+          `data: ${JSON.stringify({ total: 0, history: Array(MAX_HISTORY_POINTS).fill(0) })}\n\n`,
+        ),
+      );
+    }
+  };
+
+  // Send initial data
+  await sendStats();
+
+  // Update every 15 seconds
+  const timer = setInterval(sendStats, 15000);
+
+  request.signal.addEventListener("abort", () => {
+    clearInterval(timer);
+    writer.close();
+  });
+
+  return new Response(stream.readable, { headers });
+}
+
+export default async (request: Request, _context: Context) => {
+  // Check if this is an SSE request
+  const acceptHeader = request.headers.get("accept");
+  if (acceptHeader?.includes("text/event-stream")) {
+    return handleSSE(request);
+  }
+
+  // Regular JSON request handling
   try {
     const store = getStore("visitors-cache");
     const visitorData = await getVisitorData(store);
@@ -214,10 +291,8 @@ export default async (_request: Request, _context: Context) => {
       const response = createVisitorResponse(updatedData, total);
       return createJsonResponse(response);
     } catch (error: unknown) {
-      console.error("Error fetching Fathom data:", error);
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to fetch visitor data";
-      return createErrorResponse(errorMessage);
+      // If Fathom errors we have probably exceeded the rate limit, just return existing
+      return createJsonResponse(visitorData);
     }
   } catch (error: unknown) {
     console.error("Internal server error:", error);

--- a/netlify/edge-functions/visitors.ts
+++ b/netlify/edge-functions/visitors.ts
@@ -2,7 +2,9 @@ import { getStore } from "@netlify/blobs";
 import type { Config, Context } from "@netlify/edge-functions";
 
 const VISITORS_KEY = "visitor_counts";
-const CACHE_TTL = 6; // Fathom limits API calls to 10 times per minute
+// Fathom max limit: 6 (10 times per minute)
+// Increase to 15 seconds to avoid accidental triggering of rate limit
+const CACHE_TTL = 15;
 const MAX_HISTORY_POINTS = 10;
 const SITE_ID = "EPXKTQED";
 
@@ -43,7 +45,7 @@ function createDefaultVisitorData(index?: number): VisitorData | VisitorData[] {
 function createJsonResponse<T>(
   data: T,
   status = 200,
-  cacheControl = "public, max-age=6",
+  cacheControl = "public, max-age=15",
 ): Response {
   return new Response(JSON.stringify(data), {
     status,
@@ -228,6 +230,6 @@ export const config: Config = {
   rateLimit: {
     action: "rate_limit",
     aggregateBy: "ip",
-    windowSize: 60,
+    windowSize: 100,
   },
 };

--- a/src/components/ChannelDisplay.astro
+++ b/src/components/ChannelDisplay.astro
@@ -34,7 +34,6 @@ const calculateSvgWidth = (totalBars: number) => {
 
 function generateBars(history: number[]) {
   const maxValue = Math.max(...history, SOFT_MIN);
-  const totalBars = history.length;
 
   return history
     .map((point, i) => {
@@ -243,7 +242,6 @@ const svgWidth = calculateSvgWidth(initialVisitorData.history.length);
       const height = 10; // height in pixels
       const MIN_HEIGHT = 2; // minimum height of a bar
       const maxValue = Math.max(...this.visitorHistory, 1); // Use 1 as minimum to avoid division by zero
-      const totalBars = this.visitorHistory.length;
       const startX = 0; // No need to center since SVG width is dynamic
 
       // Clear existing bars

--- a/src/components/ChannelDisplay.astro
+++ b/src/components/ChannelDisplay.astro
@@ -337,10 +337,6 @@ const isAiring = Boolean(startTime && endTime) && program !== null;
         this.updateTimeDisplay();
       }
 
-      // Add event listeners for cleanup
-      document.addEventListener("astro:before-swap", () => this.clearTimers());
-      document.addEventListener("astro:after-swap", () => this.clearTimers());
-
       // Set up sparkline
       this.setupSparkline();
 
@@ -396,7 +392,7 @@ const isAiring = Boolean(startTime && endTime) && program !== null;
       // Set up interval for updates
       this.visitorUpdateInterval = setInterval(() => {
         this.fetchVisitorCount();
-      }, 6000); // Update every 6 seconds
+      }, 15000); // Update every 15 seconds
     }
 
     handleVisibilityChange() {

--- a/src/components/ChannelDisplay.astro
+++ b/src/components/ChannelDisplay.astro
@@ -11,7 +11,7 @@ const { program, startTime, endTime } = activeProgram ?? {};
 const { title, url } = program ?? {};
 
 // Fetch initial visitor data
-let initialVisitorData = { total: 0, history: Array(10).fill(0) };
+let initialVisitorData = { total: 0, history: Array(8).fill(0) };
 try {
   const response = await fetch("/api/visitors");
   if (response.ok) {
@@ -23,26 +23,28 @@ try {
 
 const BAR_WIDTH = 3;
 const BAR_GAP = 2;
-const SVG_WIDTH = 50;
 const SVG_HEIGHT = 10;
 const MIN_HEIGHT = 2;
 const SOFT_MIN = 5;
 
+// Calculate SVG width dynamically based on bar width and gap
+const calculateSvgWidth = (totalBars: number) => {
+  return BAR_WIDTH * totalBars + BAR_GAP * (totalBars - 1);
+};
+
 function generateBars(history: number[]) {
   const maxValue = Math.max(...history, SOFT_MIN);
   const totalBars = history.length;
-  const totalWidth = BAR_WIDTH * totalBars + BAR_GAP * (totalBars - 1);
-  const startX = (SVG_WIDTH - totalWidth) / 2;
 
   return history
-    .map((point, idx) => {
+    .map((point, i) => {
       const availableHeight = SVG_HEIGHT - MIN_HEIGHT;
       const scaledHeight =
         point <= SOFT_MIN
           ? MIN_HEIGHT + availableHeight * (point / SOFT_MIN)
           : SVG_HEIGHT * (1 - (point - SOFT_MIN) / (maxValue - SOFT_MIN));
       const barHeight = Math.max(MIN_HEIGHT, scaledHeight);
-      const x = startX + idx * (BAR_WIDTH + BAR_GAP);
+      const x = i * (BAR_WIDTH + BAR_GAP);
       const y = SVG_HEIGHT - barHeight;
 
       return `<rect x="${x}" y="${y}" width="${BAR_WIDTH}" height="${barHeight}" rx="1" fill="currentColor" />`;
@@ -69,6 +71,8 @@ const readableEndTime = getReadableTime(endTime)?.split(" ")[0];
 const isAm = getReadableTime(endTime)?.split(" ")[1] === "AM";
 
 const isAiring = Boolean(startTime && endTime) && program !== null;
+
+const svgWidth = calculateSvgWidth(initialVisitorData.history.length);
 ---
 
 <channel-display
@@ -128,7 +132,7 @@ const isAiring = Boolean(startTime && endTime) && program !== null;
         </div>
       </div>
       <div id="visitors" data-active="true">
-        <svg class="visitor-trend" width="50" height="15">
+        <svg class="visitor-trend" width={svgWidth} height="15">
           <g
             class="trend-bars"
             set:html={generateBars(initialVisitorData.history)}
@@ -144,11 +148,12 @@ const isAiring = Boolean(startTime && endTime) && program !== null;
   class ChannelDisplay extends HTMLElement {
     intervalId: NodeJS.Timer | null = null;
     timeoutId: NodeJS.Timeout | null = null;
-    visitorUpdateInterval: NodeJS.Timer | null = null;
+    private eventSource: EventSource | null = null;
     isOnline: boolean = true;
     private visitorHistory: number[] = [];
     private trendBars: SVGGElement | null = null;
-    private readonly MAX_POINTS = 10;
+    private svgElement: SVGElement | null = null;
+    private readonly MAX_POINTS = 8;
     private readonly BAR_WIDTH = 3;
     private readonly BAR_GAP = 2;
 
@@ -176,25 +181,70 @@ const isAiring = Boolean(startTime && endTime) && program !== null;
       }
     }
 
+    private setupLiveUpdates() {
+      if (this.eventSource) {
+        this.eventSource.close();
+      }
+
+      this.eventSource = new EventSource("/api/visitors");
+
+      this.eventSource.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          this.updateVisitorHistory(data.history, data.total);
+          this.updateSparkline();
+
+          // Update the count display
+          const countElement = this.querySelector("#visitors .count");
+          if (countElement) {
+            countElement.textContent = data.total.toString();
+          }
+
+          // Update active state
+          this.updateVisitorActiveState(data.total);
+        } catch (error) {
+          console.error("Error parsing SSE data:", error);
+        }
+      };
+
+      this.eventSource.onerror = () => {
+        // Close the connection if it exists
+        if (this.eventSource) {
+          this.eventSource.close();
+          this.eventSource = null;
+        }
+
+        // Attempt to reconnect after a delay
+        setTimeout(() => this.setupLiveUpdates(), 5000);
+      };
+    }
+
     private setupSparkline() {
       this.trendBars = this.querySelector(".trend-bars");
-      if (!this.trendBars) return;
+      this.svgElement = this.querySelector(".visitor-trend");
+      if (!this.trendBars || !this.svgElement) return;
 
       this.updateSparkline();
     }
 
+    // Calculate SVG width dynamically based on bar width and gap
+    private calculateSvgWidth(totalBars: number): number {
+      return this.BAR_WIDTH * totalBars + this.BAR_GAP * (totalBars - 1);
+    }
+
     private updateSparkline() {
-      if (!this.trendBars) return;
+      if (!this.trendBars || !this.svgElement) return;
+
+      // Update SVG width based on number of bars
+      const svgWidth = this.calculateSvgWidth(this.visitorHistory.length);
+      this.svgElement.setAttribute("width", svgWidth.toString());
 
       // Calculate dimensions
-      const width = 50;
       const height = 10; // height in pixels
       const MIN_HEIGHT = 2; // minimum height of a bar
       const maxValue = Math.max(...this.visitorHistory, 1); // Use 1 as minimum to avoid division by zero
       const totalBars = this.visitorHistory.length;
-      const totalWidth =
-        this.BAR_WIDTH * totalBars + this.BAR_GAP * (totalBars - 1);
-      const startX = (width - totalWidth) / 2; // Center the bars
+      const startX = 0; // No need to center since SVG width is dynamic
 
       // Clear existing bars
       this.trendBars.innerHTML = "";
@@ -218,50 +268,8 @@ const isAiring = Boolean(startTime && endTime) && program !== null;
         rect.setAttribute("rx", "1");
         rect.setAttribute("fill", "currentColor");
 
-        if (this.trendBars) {
-          this.trendBars.appendChild(rect);
-        }
+        this.trendBars?.appendChild(rect);
       });
-    }
-
-    async fetchVisitorCount() {
-      if (!this.isOnline) return;
-
-      try {
-        const response = await fetch("/api/visitors");
-        if (!response.ok) {
-          throw new Error(`Failed to fetch visitor count: ${response.status}`);
-        }
-
-        const data = await response.json();
-
-        // Validate the data structure
-        if (!data || typeof data.total !== "number") {
-          throw new Error("Invalid visitor data received");
-        }
-
-        const visitorCount = data.total;
-        const countElement = this.querySelector("#visitors .count");
-
-        if (!countElement) {
-          console.warn("Visitor count element not found");
-          return;
-        }
-
-        // Update the count display
-        countElement.textContent = visitorCount.toString();
-
-        // Update visitor history
-        this.updateVisitorHistory(data.history, visitorCount);
-
-        // Update the sparkline visualization
-        this.updateSparkline();
-
-        // Update the active state based on visitor count
-        this.updateVisitorActiveState(visitorCount);
-      } catch (error) {
-        console.error("Error fetching visitor count:", error);
-      }
     }
 
     /**
@@ -340,8 +348,8 @@ const isAiring = Boolean(startTime && endTime) && program !== null;
       // Set up sparkline
       this.setupSparkline();
 
-      // Set up visitor count updates
-      this.setupVisitorUpdates();
+      // Set up live updates
+      this.setupLiveUpdates();
 
       // Add visibility change listener
       document.addEventListener(
@@ -385,29 +393,19 @@ const isAiring = Boolean(startTime && endTime) && program !== null;
       }
     }
 
-    setupVisitorUpdates() {
-      // Initial fetch
-      this.fetchVisitorCount();
-
-      // Set up interval for updates
-      this.visitorUpdateInterval = setInterval(() => {
-        this.fetchVisitorCount();
-      }, 15000); // Update every 15 seconds
-    }
-
     handleVisibilityChange() {
       this.isOnline = document.visibilityState === "visible";
       if (this.isOnline) {
-        this.fetchVisitorCount();
+        this.setupLiveUpdates();
       }
     }
 
     disconnectedCallback() {
       this.clearTimers();
 
-      if (this.visitorUpdateInterval !== null) {
-        clearInterval(this.visitorUpdateInterval);
-        this.visitorUpdateInterval = null;
+      if (this.eventSource) {
+        this.eventSource.close();
+        this.eventSource = null;
       }
 
       document.removeEventListener(
@@ -424,11 +422,6 @@ const isAiring = Boolean(startTime && endTime) && program !== null;
       if (this.timeoutId !== null) {
         clearTimeout(this.timeoutId);
         this.timeoutId = null;
-      }
-
-      if (this.visitorUpdateInterval !== null) {
-        clearInterval(this.visitorUpdateInterval);
-        this.visitorUpdateInterval = null;
       }
     }
 
@@ -623,17 +616,8 @@ const isAiring = Boolean(startTime && endTime) && program !== null;
     .visitor-trend {
       overflow: visible;
       position: relative;
-
-      &::before {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background: linear-gradient(
-          to right,
-          var(--phosphor-active) 0%,
-          transparent 100%
-        );
-      }
+      /* Optical alignment */
+      transform: translateY(2px);
 
       rect {
         transition: all 0.3s ease-out;

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -199,12 +199,17 @@
             `[data-setting="${setting.name}"]`,
           );
           if (toggleElement) {
-            const savedState =
-              localStorage.getItem(setting.localStorageKey) === "true";
-            toggleElement.setAttribute(
-              "data-on",
-              savedState ? "true" : "false",
-            );
+            const savedState = localStorage.getItem(setting.localStorageKey);
+            const isOn =
+              savedState === null
+                ? setting.defaultValue === "true"
+                : savedState === "true";
+            toggleElement.setAttribute("data-on", isOn ? "true" : "false");
+
+            // Also trigger the setting change to ensure the event is fired
+            this.handleSettingChange(setting.name, isOn.toString(), {
+              doNotTrack: true,
+            });
           }
         }
       });

--- a/src/components/Television.astro
+++ b/src/components/Television.astro
@@ -41,8 +41,12 @@ const { activeProgram, channelId, channelName } = Astro.props;
     selector: string,
     attribute: string,
     defaultValue: string = "0",
+    detailProperty?: string,
   ): void {
-    const savedValue = localStorage.getItem(attribute) || defaultValue;
+    // Use the specified detail property or fall back to the attribute name without 'data-' prefix
+    const localStorageKey = detailProperty || attribute.replace("data-", "");
+
+    const savedValue = localStorage.getItem(localStorageKey) || defaultValue;
     setAttributeOnElement(selector, attribute, savedValue);
   }
 


### PR DESCRIPTION
Resolves #12.
Resolves(?) #13 

- Decrease cache TTL from 6 seconds to 15 seconds to avoid hitting Fathom API rate limit
- Use `TransformStream` for more reliable event streaming
- Fix initialization of menu settings to the TV screen overlay on page load