### PR TITLE
Fix contributor sorting to handle lowercase names

### DIFF
--- a/src/pages/api/contributors.json.ts
+++ b/src/pages/api/contributors.json.ts
@@ -17,7 +17,9 @@ async function listAllContributors() {
   );
 
   // Remove duplicates and sort
-  return [...new Set(allContributors)].sort();
+  return [...new Set(allContributors)].sort((a, b) =>
+    a.toLowerCase().localeCompare(b.toLowerCase()),
+  );
 }
 
 export const GET: APIRoute = async () => {


### PR DESCRIPTION
The default sort for contributors on the credits page was putting lowercase names at the end. This fixes the contributors API to return an alphabetized set of all names, ignoring capitalization