### PR TITLE
Update the channel display end time to show local time

### DIFF
--- a/src/components/ChannelDisplay.astro
+++ b/src/components/ChannelDisplay.astro
@@ -57,7 +57,7 @@ function getReadableTime(timeStr: string | undefined) {
   // Create a new date and set it to the time from the string
   const [hours, minutes] = timeStr.split(":").map(Number);
   const date = new Date();
-  date.setHours(hours, minutes, 0, 0);
+  date.setUTCHours(hours, minutes, 0, 0);
 
   return date.toLocaleTimeString("en-US", {
     hour: "2-digit",
@@ -366,7 +366,7 @@ const svgWidth = calculateSvgWidth(initialVisitorData.history.length);
       // Parse the time string and convert to local time
       const [hours, minutes] = timeStr.split(":").map(Number);
       const date = new Date();
-      date.setHours(hours, minutes, 0, 0);
+      date.setUTCHours(hours, minutes, 0, 0);
 
       // Format the time
       const formattedTime = date.toLocaleTimeString("en-US", {


### PR DESCRIPTION
Fixes an issue where the end time for the time display was set using local time instead of UTC time.