### PR TITLE
Don't call visitors API during local development

### DIFF
--- a/src/channels/04-personal.yml
+++ b/src/channels/04-personal.yml
@@ -139,6 +139,9 @@ schedule:
     - "03:00":
     - "03:30":
     - "04:00":
+        title: Yihui
+        author: Yihui H
+        url: https://www.yihui.work
     - "04:30":
     - "05:00":
     - "05:30":

--- a/src/components/ChannelDisplay.astro
+++ b/src/components/ChannelDisplay.astro
@@ -12,13 +12,15 @@ const { title, url } = program ?? {};
 
 // Fetch initial visitor data
 let initialVisitorData = { total: 0, history: Array(8).fill(0) };
-try {
-  const response = await fetch("/api/visitors");
-  if (response.ok) {
-    initialVisitorData = await response.json();
+if (!import.meta.env.DEV) {
+  try {
+    const response = await fetch("/api/visitors");
+    if (response.ok) {
+      initialVisitorData = await response.json();
+    }
+  } catch (error) {
+    console.error("Failed to fetch initial visitor data:", error);
   }
-} catch (error) {
-  console.error("Failed to fetch initial visitor data:", error);
 }
 
 const BAR_WIDTH = 3;


### PR DESCRIPTION
Prevent console errors from clogging the terminal when developing locally.