### PR TITLE
More new art + single-use sites for May

### DIFF
--- a/src/channels/02-art.yml
+++ b/src/channels/02-art.yml
@@ -89,6 +89,8 @@ schedule:
     - "07:00":
     - "07:30":
     - "08:00":
+        title: Sun Clock
+        url: https://sunclock.net/
     - "08:30":
     - "09:00":
     - "09:30":
@@ -145,6 +147,9 @@ schedule:
     - "03:00":
     - "03:30":
     - "04:00":
+        title: ASCII Theater
+        author: MSCHF
+        url: https://ascii.theater/
     - "04:30":
     - "05:00":
     - "05:30":
@@ -162,6 +167,9 @@ schedule:
     - "10:00":
     - "10:30":
     - "11:00":
+        title: Fungal Page
+        author: Raphaël Bastide
+        url: https://fungal.page/
     - "11:30":
     - "12:00":
     - "12:30":
@@ -181,6 +189,9 @@ schedule:
     - "18:00":
     - "18:30":
     - "19:00":
+        title: Mondrian and Me
+        author: Tim Holman
+        url: https://mondrianandme.com/
     - "19:30":
     - "20:00":
     - "20:30":
@@ -261,6 +272,8 @@ schedule:
     - "02:00":
     - "02:30":
     - "03:00":
+        title: Lorem Ipsum
+        url: https://t-h-e-s-p-a-c-e.com/lorem-ipsum/
     - "03:30":
     - "04:00":
     - "04:30":
@@ -270,6 +283,9 @@ schedule:
     - "06:30":
     - "07:00":
     - "07:30":
+        title: Jordan Belson Landscapes
+        author: Jordan Belson
+        url: https://matthewmarks.com/online/jordan-belson
     - "08:00":
     - "08:30":
     - "09:00":
@@ -284,6 +300,9 @@ schedule:
         url: https://proto.sh/
     - "12:30":
     - "13:00":
+        title: Objectified
+        author: Chester Fernandez
+        url: https://www.objectifiedcomic.com/
     - "13:30":
     - "14:00":
     - "14:30":

--- a/src/channels/03-music.yml
+++ b/src/channels/03-music.yml
@@ -249,6 +249,8 @@ schedule:
     - "09:00":
     - "09:30":
     - "10:00":
+        title: WFMU
+        url: https://wfmu.org/
     - "10:30":
     - "11:00":
     - "11:30":
@@ -261,8 +263,6 @@ schedule:
     - "15:00":
     - "15:30":
     - "16:00":
-        title: WFMU
-        url: https://wfmu.org/
     - "16:30":
         title: Ear Association
         author:

--- a/src/channels/04-personal.yml
+++ b/src/channels/04-personal.yml
@@ -186,6 +186,9 @@ schedule:
     - "19:00":
     - "19:30":
     - "20:00":
+        title: Karl Sims
+        author: Karl Sims
+        url: https://karlsims.com/
     - "20:30":
     - "21:00":
     - "21:30":

--- a/src/channels/06-single-use.yml
+++ b/src/channels/06-single-use.yml
@@ -113,6 +113,9 @@ schedule:
     - "16:00":
     - "16:30":
     - "17:00":
+        title: Elevator.js
+        author: Tim Holman
+        url: https://tholman.com/elevator.js/
     - "17:30":
     - "18:00":
     - "18:30":
@@ -120,6 +123,9 @@ schedule:
     - "19:30":
     - "20:00":
     - "20:30":
+        title: Meet the Ipsums
+        author: Tim Holman
+        url: https://meettheipsums.com/
     - "21:00":
     - "21:30":
     - "22:00":
@@ -146,6 +152,9 @@ schedule:
     - "06:30":
     - "07:00":
     - "07:30":
+        title: Reaction Diffusion Explorer
+        author: Karl Sims
+        url: https://karlsims.com/rdtool.html
     - "08:00":
     - "08:30":
     - "09:00":

--- a/src/channels/07-explorables.yml
+++ b/src/channels/07-explorables.yml
@@ -118,6 +118,9 @@ schedule:
     - "20:00":
     - "20:30":
     - "21:00":
+        title: Making Software
+        author: Dan Hollick
+        url: https://www.makingsoftware.com/
     - "21:30":
     - "22:00":
     - "22:30":
@@ -169,6 +172,9 @@ schedule:
     - "17:00":
     - "17:30":
     - "18:00":
+        title: Practical Typography
+        author: Matthew Butterick
+        url: https://practicaltypography.com/
     - "18:30":
     - "19:00":
     - "19:30":

--- a/src/channels/09-misc.yml
+++ b/src/channels/09-misc.yml
@@ -72,6 +72,9 @@ schedule:
     - "05:00":
     - "05:30":
     - "06:00":
+        title: Resizabill
+        author: Anatoly Zenkov
+        url: https://anatolyzenkov.com/resizabill
     - "06:30":
     - "07:00":
     - "07:30":
@@ -125,6 +128,9 @@ schedule:
     - "04:30":
     - "05:00":
     - "05:30":
+        title: Pug in a Rug
+        author: Tim Holman
+        url: https://puginarug.com/
     - "06:00":
     - "06:30":
     - "07:00":
@@ -140,6 +146,9 @@ schedule:
     - "12:00":
     - "12:30":
     - "13:00":
+        title: The Finger
+        author: Tim Holman
+        url: https://thatsthefinger.com/
     - "13:30":
     - "14:00":
     - "14:30":

--- a/src/components/RotatingLogo.astro
+++ b/src/components/RotatingLogo.astro
@@ -45,8 +45,6 @@
     const renderer = new THREE.WebGLRenderer({
       powerPreference: "low-power",
       alpha: true,
-      antialias: false,
-      preserveDrawingBuffer: true,
     });
     renderer.setAnimationLoop(animate);
     renderer.toneMapping = THREE.ACESFilmicToneMapping;


### PR DESCRIPTION
## What site(s) did you add?
https://sunclock.net/
https://ascii.theater/
https://fungal.page/
https://mondrianandme.com/
https://t-h-e-s-p-a-c-e.com/lorem-ipsum/
https://matthewmarks.com/online/jordan-belson
https://www.objectifiedcomic.com/
https://karlsims.com/
https://tholman.com/elevator.js/
https://meettheipsums.com/
https://karlsims.com/rdtool.html
https://www.makingsoftware.com/
https://practicaltypography.com/
https://anatolyzenkov.com/resizabill
https://puginarug.com/
https://thatsthefinger.com/

- [x] I verified that the sites display without issues using https://hypertext.tv/test
- [x] There are no ads on the sites